### PR TITLE
update coding_style.md with StandardJS and Meteor

### DIFF
--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -2,42 +2,44 @@
 # Standard JS - The Rules
 
 
-* **2 spaces ** - for identation
-
+* **2 spaces** - for identation
+<br>
 * **Single quotes for strings** - except to avoid
 escaping
-
+<br>
 * **No unused variables** - this one catches *tons* of bugs!
-
+<br>
 * **No semicolons** - [It's](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding)
 [ fine.](http://inimino.org/~inimino/blog/javascript_semicolons)
 [ Really!](https://www.youtube.com/watch?v=gsfbh17Ax9I)
-
-* **Never start a line with <span style="font-family: Courier">(,[, or `</span> **
+<br>
+* **Never start a line with <span style="font-family: Courier">(,[, or `</span>**
   * This is the **only** gotcha with omitting semicolons - *automatically checked for you!*
   * [More details](https://standardjs.com/rules-en.html#semicolons)
-
+<br>
 * **Space after keywords:**
 <span style="font-family: Courier">
-<br>if (condition) {...}
+<br>
+&nbsp;&nbsp;if (condition) {...}
 </span>
-
+<br>
 * **Space after function name:**
 <span style="font-family: Courier">
-<br>function name (arg) { ... }
+<br>
+&nbsp;&nbsp;function name (arg) { ... }
 </span>
-
+<br>
 * **Always use** <span style="font-family: Courier">===</span> instead of <span style="font-family: Courier">==</span>
  * But <span style="font-family: Courier">obj == null</span> is allowed to check  <span style="font-family: Courier">null || undefined</span>.
-
+<br>
 * **Always handle** the <span style="font-family: Courier">node.js err</span> function parameter
-
+<br>
 * **Always prefix** browser globals with <span style="font-family: Courier">window</span>
  * Except <span style="font-family: Courier">document</span> and
   <span style="font-family: Courier">navigator</span> are okay.
    * Prevents accidental use of poorly-named browser globals like <span style="font-family: Courier">open, length, event,</span> and
    <span style="font-family: Courier">name</span>.
-
+<br>
 * **And** [more goodness](https://standardjs.com/rules-en.html#javascript-standard-style) – *give <span style="font-family: Courier">standard</span> a try today!*
 
 To get a better idea, take a look at [a sample file](https://github.com/expressjs/body-parser/blob/master/index.js) written in JavaScript Standard Style. Or, check out one of the [thousands of projects](https://raw.githubusercontent.com/standard/standard-packages/master/all.json) that use <span style="font-family: Courier">standard!</span>

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -46,7 +46,7 @@ To get a better idea, take a look at [a sample file](https://github.com/expressj
 ##### Use the `ecmascript` package
 ECMAScript, the language standard on which every browser’s JavaScript implementation is based, has moved to yearly standards releases... Meteor’s `ecmascript` package compiles this standard down to regular JavaScript that all browsers can understand using the popular Babel compiler. It’s fully backwards compatible to “regular” JavaScript, so you don’t have to use any new features if you don’t want to. We’ve put a lot of effort into making advanced browser features like source maps work great with this package, so that you can debug your code using your favorite developer tools without having to see any of the compiled output.
 
-The `ecmascript` `package is included in all new apps and packages by default, and compiles all files with the .js file extension automatically. See the [list of all ES2015 features supported by the ecmascript package](https://docs.meteor.com/packages/ecmascript.html#Supported-ES2015-Features).
+The `ecmascript` package is included in all new apps and packages by default, and compiles all files with the .js file extension automatically. See the [list of all ES2015 features supported by the ecmascript package](https://docs.meteor.com/packages/ecmascript.html#Supported-ES2015-Features).
 
 To get the full experience, you should also use the `es5-shim` package which is included in all new apps by default. This means you can rely on runtime features like `Array#forEach` without worrying about which browsers support them.
 

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -1,8 +1,8 @@
 #### Coding Style Guide
-# Standard JS - The Rules
+##### Standard JS - The Rules
 
 
-* **2 spaces** - for identation
+* **2 spaces** - for indentation
 
 * **Single quotes for strings** - except to avoid
 escaping
@@ -14,7 +14,7 @@ escaping
 [ Really!](https://www.youtube.com/watch?v=gsfbh17Ax9I)
 
 * **Never start a line with `(,[,` or `` ` ``!**
-  * This is the **only** gotcha with omitting semicolons - *automatically checked for you!*
+  * This is the **only** gotcha with omitting semicolons - * they are automatically checked for you!*
   * [More details](https://standardjs.com/rules-en.html#semicolons)
 
 * **Space after keywords:** `if (condition) {...}`

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -13,27 +13,26 @@ escaping
 [ fine.](http://inimino.org/~inimino/blog/javascript_semicolons)
 [ Really!](https://www.youtube.com/watch?v=gsfbh17Ax9I)
 
-* **Never start a line with <span style="font-family: Courier">(,[, or `</span>**
+* **Never start a line with `(,[,` or `` ` ``!**
   * This is the **only** gotcha with omitting semicolons - *automatically checked for you!*
   * [More details](https://standardjs.com/rules-en.html#semicolons)
 
-* **Space after keywords:** <span style="font-family: Courier">&nbsp;&nbsp;if (condition) {...}</span>
+* **Space after keywords:** `if (condition) {...}`
 
-* **Space after function name:** <span style="font-family: Courier">&nbsp;&nbsp;function name (arg) { ... }</span>
+* **Space after function name:** `function name (arg) { ... }`
 
-* **Always use** <span style="font-family: Courier">===</span> instead of <span style="font-family: Courier">==</span>
- * But <span style="font-family: Courier">obj == null</span> is allowed to check  <span style="font-family: Courier">null || undefined</span>.
+* **Always use** `===` instead of `==`
+ * The use of `obj == null` is allowed to check for `null || undefined`
 
-* **Always handle** the <span style="font-family: Courier">node.js err</span> function parameter
+* **Always handle** the `node.js err` function parameter
 
-* **Always prefix** browser globals with <span style="font-family: Courier">window</span>
- * Except <span style="font-family: Courier">document</span> and
-  <span style="font-family: Courier">navigator</span> are okay.
-   * Prevents accidental use of poorly-named browser globals like <span style="font-family: Courier">open, length, event,</span> and
-   <span style="font-family: Courier">name</span>.
+* **Always prefix** browser globals with `window`
+ * Except for `document` and `navigator`, which are okay.
+   * This prevents accidental use of poorly-named browser globals like `open, length, event,` and
+   `name`.
 
-* **And** [more goodness](https://standardjs.com/rules-en.html#javascript-standard-style) – *give <span style="font-family: Courier">standard</span> a try today!*
+* **And** [more goodness](https://standardjs.com/rules-en.html#javascript-standard-style) – *give `standard` a try today!*
 
-To get a better idea, take a look at [a sample file](https://github.com/expressjs/body-parser/blob/master/index.js) written in JavaScript Standard Style. Or, check out one of the [thousands of projects](https://raw.githubusercontent.com/standard/standard-packages/master/all.json) that use <span style="font-family: Courier">standard!</span>
+To get a better idea, take a look at [a sample file](https://github.com/expressjs/body-parser/blob/master/index.js) written in JavaScript Standard Style. Or, check out one of the [thousands of projects](https://raw.githubusercontent.com/standard/standard-packages/master/all.json) that use `standard!`
 
 <cite> Courtesy of [StandardJS.com](https://standardjs.com/)</cite>

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -3,43 +3,43 @@
 
 
 * **2 spaces** - for identation
-<br>
+
 * **Single quotes for strings** - except to avoid
 escaping
-<br>
+
 * **No unused variables** - this one catches *tons* of bugs!
-<br>
+
 * **No semicolons** - [It's](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding)
 [ fine.](http://inimino.org/~inimino/blog/javascript_semicolons)
 [ Really!](https://www.youtube.com/watch?v=gsfbh17Ax9I)
-<br>
+
 * **Never start a line with <span style="font-family: Courier">(,[, or `</span>**
   * This is the **only** gotcha with omitting semicolons - *automatically checked for you!*
   * [More details](https://standardjs.com/rules-en.html#semicolons)
-<br>
+
 * **Space after keywords:**
 <span style="font-family: Courier">
 <br>
 &nbsp;&nbsp;if (condition) {...}
 </span>
-<br>
+
 * **Space after function name:**
 <span style="font-family: Courier">
 <br>
 &nbsp;&nbsp;function name (arg) { ... }
 </span>
-<br>
+
 * **Always use** <span style="font-family: Courier">===</span> instead of <span style="font-family: Courier">==</span>
  * But <span style="font-family: Courier">obj == null</span> is allowed to check  <span style="font-family: Courier">null || undefined</span>.
-<br>
+
 * **Always handle** the <span style="font-family: Courier">node.js err</span> function parameter
-<br>
+
 * **Always prefix** browser globals with <span style="font-family: Courier">window</span>
  * Except <span style="font-family: Courier">document</span> and
   <span style="font-family: Courier">navigator</span> are okay.
    * Prevents accidental use of poorly-named browser globals like <span style="font-family: Courier">open, length, event,</span> and
    <span style="font-family: Courier">name</span>.
-<br>
+
 * **And** [more goodness](https://standardjs.com/rules-en.html#javascript-standard-style) – *give <span style="font-family: Courier">standard</span> a try today!*
 
 To get a better idea, take a look at [a sample file](https://github.com/expressjs/body-parser/blob/master/index.js) written in JavaScript Standard Style. Or, check out one of the [thousands of projects](https://raw.githubusercontent.com/standard/standard-packages/master/all.json) that use <span style="font-family: Courier">standard!</span>

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -19,13 +19,11 @@ escaping
 
 * **Space after keywords:**
 <span style="font-family: Courier">
-<br>
 &nbsp;&nbsp;if (condition) {...}
 </span>
 
 * **Space after function name:**
 <span style="font-family: Courier">
-<br>
 &nbsp;&nbsp;function name (arg) { ... }
 </span>
 

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -1,4 +1,45 @@
 #### Coding Style Guide
-----
+# Standard JS - The Rules
 
-Coming Soon
+
+* **2 spaces ** - for identation
+
+* **Single quotes for strings** - except to avoid
+escaping
+
+* **No unused variables** - this one catches *tons* of bugs!
+
+* **No semicolons** - [It's](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding)
+[ fine.](http://inimino.org/~inimino/blog/javascript_semicolons)
+[ Really!](https://www.youtube.com/watch?v=gsfbh17Ax9I)
+
+* **Never start a line with <span style="font-family: Courier">(,[, or `</span> **
+  * This is the **only** gotcha with omitting semicolons - *automatically checked for you!*
+  * [More details](https://standardjs.com/rules-en.html#semicolons)
+
+* **Space after keywords:**
+<span style="font-family: Courier">
+<br>if (condition) {...}
+</span>
+
+* **Space after function name:**
+<span style="font-family: Courier">
+<br>function name (arg) { ... }
+</span>
+
+* **Always use** <span style="font-family: Courier">===</span> instead of <span style="font-family: Courier">==</span>
+ * But <span style="font-family: Courier">obj == null</span> is allowed to check  <span style="font-family: Courier">null || undefined</span>.
+
+* **Always handle** the <span style="font-family: Courier">node.js err</span> function parameter
+
+* **Always prefix** browser globals with <span style="font-family: Courier">window</span>
+ * Except <span style="font-family: Courier">document</span> and
+  <span style="font-family: Courier">navigator</span> are okay.
+   * Prevents accidental use of poorly-named browser globals like <span style="font-family: Courier">open, length, event,</span> and
+   <span style="font-family: Courier">name</span>.
+
+* **And** [more goodness](https://standardjs.com/rules-en.html#javascript-standard-style) – *give <span style="font-family: Courier">standard</span> a try today!*
+
+To get a better idea, take a look at [a sample file](https://github.com/expressjs/body-parser/blob/master/index.js) written in JavaScript Standard Style. Or, check out one of the [thousands of projects](https://raw.githubusercontent.com/standard/standard-packages/master/all.json) that use <span style="font-family: Courier">standard!</span>
+
+<cite> Courtesy of [StandardJS.com](https://standardjs.com/)</cite>

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -1,4 +1,4 @@
-### Coding Style Guide
+### Coding Style Guide<a name="styleGuide"></a>
 #### Standard JS - The Rules
 
 
@@ -36,3 +36,20 @@ escaping
 To get a better idea, take a look at [a sample file](https://github.com/expressjs/body-parser/blob/master/index.js) written in JavaScript Standard Style. Or, check out one of the [thousands of projects](https://raw.githubusercontent.com/standard/standard-packages/master/all.json) that use `standard!`
 
 <cite> Courtesy of [StandardJS.com](https://standardjs.com/)</cite>
+
+#### JavaScript Style Recommendations from [Meteor](https://guide.meteor.com/code-style.html#javascript)
+
+<img src="https://guide.meteor.com/images/ben-es2015-demo.gif" alt="Refactoring">
+
+<cite> An example of refactoring from JavaScript to ES2015</cite>
+
+##### Use the `ecmascript` package
+ECMAScript, the language standard on which every browser’s JavaScript implementation is based, has moved to yearly standards releases... Meteor’s `ecmascript` package compiles this standard down to regular JavaScript that all browsers can understand using the popular Babel compiler. It’s fully backwards compatible to “regular” JavaScript, so you don’t have to use any new features if you don’t want to. We’ve put a lot of effort into making advanced browser features like source maps work great with this package, so that you can debug your code using your favorite developer tools without having to see any of the compiled output.
+
+The `ecmascript` `package is included in all new apps and packages by default, and compiles all files with the .js file extension automatically. See the [list of all ES2015 features supported by the ecmascript package](https://docs.meteor.com/packages/ecmascript.html#Supported-ES2015-Features).
+
+To get the full experience, you should also use the `es5-shim` package which is included in all new apps by default. This means you can rely on runtime features like `Array#forEach` without worrying about which browsers support them.
+
+##### Follow a JavaScript style guide
+
+We recommend choosing and sticking to a JavaScript [style guide](styleGuide) and enforcing it with tools.

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -27,9 +27,8 @@ escaping
 * **Always handle** the `node.js err` function parameter
 
 * **Always prefix** browser globals with `window`
- * Except for `document` and `navigator`, which are okay.
-   * This prevents accidental use of poorly-named browser globals like `open, length, event,` and
-   `name`.
+  * Except for `document` and `navigator`, which are okay.
+    * This prevents accidental use of poorly-named browser globals like `open, length, event,` and `name`.
 
 * **And** [more goodness](https://standardjs.com/rules-en.html#javascript-standard-style) – *give `standard` a try today!*
 

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -35,13 +35,13 @@ escaping
 
 To get a better idea, take a look at [a sample file](https://github.com/expressjs/body-parser/blob/master/index.js) written in JavaScript Standard Style. Or, check out one of the [thousands of projects](https://raw.githubusercontent.com/standard/standard-packages/master/all.json) that use `standard!`
 
-<cite> Courtesy of [StandardJS.com](https://standardjs.com/)</cite>
+>Courtesy of [StandardJS.com](https://standardjs.com/)</cite>
 
 #### JavaScript Style Recommendations from [Meteor](https://guide.meteor.com/code-style.html#javascript)
 
 <img src="https://guide.meteor.com/images/ben-es2015-demo.gif" alt="Refactoring">
 
-<cite> An example of refactoring from JavaScript to ES2015</cite>
+> An example of refactoring from JavaScript to ES2015
 
 ##### Use the `ecmascript` package
 ECMAScript, the language standard on which every browser’s JavaScript implementation is based, has moved to yearly standards releases... Meteor’s `ecmascript` package compiles this standard down to regular JavaScript that all browsers can understand using the popular Babel compiler. It’s fully backwards compatible to “regular” JavaScript, so you don’t have to use any new features if you don’t want to. We’ve put a lot of effort into making advanced browser features like source maps work great with this package, so that you can debug your code using your favorite developer tools without having to see any of the compiled output.

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -51,4 +51,4 @@ To get the full experience, you should also use the `es5-shim` package which is 
 
 ##### Follow a JavaScript style guide
 
-We recommend choosing and sticking to a JavaScript [style guide](styleGuide) and enforcing it with tools.
+We recommend choosing and sticking to a JavaScript [style guide](#styleGuide) and enforcing it with tools.

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -1,5 +1,5 @@
-#### Coding Style Guide
-##### Standard JS - The Rules
+### Coding Style Guide
+#### Standard JS - The Rules
 
 
 * **2 spaces** - for indentation

--- a/contribution/coding_style.md
+++ b/contribution/coding_style.md
@@ -17,15 +17,9 @@ escaping
   * This is the **only** gotcha with omitting semicolons - *automatically checked for you!*
   * [More details](https://standardjs.com/rules-en.html#semicolons)
 
-* **Space after keywords:**
-<span style="font-family: Courier">
-&nbsp;&nbsp;if (condition) {...}
-</span>
+* **Space after keywords:** <span style="font-family: Courier">&nbsp;&nbsp;if (condition) {...}</span>
 
-* **Space after function name:**
-<span style="font-family: Courier">
-&nbsp;&nbsp;function name (arg) { ... }
-</span>
+* **Space after function name:** <span style="font-family: Courier">&nbsp;&nbsp;function name (arg) { ... }</span>
 
 * **Always use** <span style="font-family: Courier">===</span> instead of <span style="font-family: Courier">==</span>
  * But <span style="font-family: Courier">obj == null</span> is allowed to check  <span style="font-family: Courier">null || undefined</span>.


### PR DESCRIPTION
this update to coding_style.md captures the JavaScript Standard Style guide and Meteor JavaScript style guide and adds them into the markdown format used by this project.

attribution is used here in the forms of links and block quotes to the original source content