### PR TITLE
Issue 16

### DIFF
--- a/contribution/development_environment.md
+++ b/contribution/development_environment.md
@@ -11,21 +11,19 @@
   - Click on  "Fork" near the upper right.
 
 4. Once you have a copy of this repo on your own account, clone this repo to your computer by typing in something like:
-
-  `git clone https://github.com/[Your URL Path here]/codebuddies.git`
-
-  (Replace the URL with your own repository URL path.)
-  *Note: You can also get the above link to clone the repo by going to the github page for your fork of the repo on your account and clinking "Clone or download."*
+   `git clone https://github.com/[Your URL Path here]/codebuddies.git`
+  - Replace the URL with your own repository URL path.
+  - You can also get the above link to clone the repo by going to the github page for your fork of the repo and clinking "Clone or download."
 
 5. Type `cd codebuddies` in your terminal. Then, set up this repository as an upstream branch by typing:
-  * `git remote add upstream https://github.com/codebuddies/codebuddies.git`
+  `git remote add upstream https://github.com/codebuddies/codebuddies.git`
 
 6. Type `meteor npm install` to install the initial meteor packages. You have to do this once!
 
 Now, whenever you want to sync with the owner repository, you can do the following:
-  * `git fetch upstream`
-  * `git checkout staging`
-  * `git merge upstream/staging`
+  - `git fetch upstream`
+  - `git checkout staging`
+  - `git merge upstream/staging`
 
   Note: You can type `git remote -v` to check which repositories your `origin` and `upstream` are pointing to.
 

--- a/contribution/development_environment.md
+++ b/contribution/development_environment.md
@@ -4,17 +4,23 @@
 1. Install Meteor. On a mac, you should use this command:
 
    `curl "https://install.meteor.com/?release=1.6.1.1" | sh`
+   - On Windows, you should run the official installer [here](https://www.meteor.com/install).
+   - If you're unsure whether you already have meteor installed, type `meteor --version` in your command line to check. You should see that you have meteor version 1.3.2.4.
 
-On Windows, you should run the official installer [here](https://www.meteor.com/install). If you're unsure whether you already have meteor installed, type `meteor --version` in your command line to check. You should see that you have meteor version 1.3.2.4.
+2. Go to [https://github.com/codebuddies/codebuddies](https://github.com/codebuddies/codebuddies). Fork this repository!
+  - Click on  "Fork" near the upper right.
 
-2. Fork this repository! Once you have a copy of this repo on your own account, clone this repo to your computer by typing in something like:
+4. Once you have a copy of this repo on your own account, clone this repo to your computer by typing in something like:
 
-  `git clone https://github.com/codebuddies/codebuddies.git`
+  `git clone https://github.com/[Your URL Path here]/codebuddies.git`
 
   (Replace the URL with your own repository URL path.)
+  *Note: You can also get the above link to clone the repo by going to the github page for your fork of the repo on your account and clinking "Clone or download."*
 
-3. Type `cd codebuddies` in your terminal. Then, set up this repository as an upstream branch by typing:
-  * `git remote add upstream https://github.com/codebuddies/cb-v2-scratch.git`
+5. Type `cd codebuddies` in your terminal. Then, set up this repository as an upstream branch by typing:
+  * `git remote add upstream https://github.com/codebuddies/codebuddies.git`
+
+6. Type `meteor npm install` to install the initial meteor packages. You have to do this once!
 
 Now, whenever you want to sync with the owner repository, you can do the following:
   * `git fetch upstream`
@@ -23,7 +29,7 @@ Now, whenever you want to sync with the owner repository, you can do the followi
 
   Note: You can type `git remote -v` to check which repositories your `origin` and `upstream` are pointing to.
 
-4. Type `meteor npm install` to install the initial meteor packages. You have to do this once!
+
 
 
 


### PR DESCRIPTION
- Made "Fork" and "Clone" steps two separate numbered steps. Altered markdown for readability. 
- Clarified that URL path for cloning repo is user's own repo not generic one listed. 
- Moved NPM install step up. 