### PR TITLE
Updated quick_steps.md with extra links

### DIFF
--- a/contribution/quick_steps.md
+++ b/contribution/quick_steps.md
@@ -4,10 +4,10 @@
 1. Join the CodeBuddies community on Slack. (Get your invite [here](http://codebuddiesmeet.herokuapp.com))
 2. [Install meteor](development_environment.md)
 3. Fork and clone the repository.
-4. Set up your development environment.
-5. Look through the issues and find one you want to work on. If you have questions, leave a comment or ask in the #codebuddies-meta channel on slack.
-6. Create a branch on the issue you want to work on. Name it the issue number, like `issue-503`.
-7. Submit a pull request and associate it with the issue.
+4. Set up your [development environment](https://docs.codebuddies.org/code-contribution/development_environment).
+5. [Look through the issues and find one you want to work on](https://docs.codebuddies.org/code-contribution/issue). If you have questions, leave a comment or ask in the #codebuddies-meta channel on slack.
+6. [Create a branch on the issue you want to work on](https://docs.codebuddies.org/code-contribution/branch). Name it the issue number, like `issue-503`.
+7. [Submit a pull request](https://docs.codebuddies.org/code-contribution/pull_request) and associate it with the issue.
 8. Submit a pull request to add yourself as a contributor to both the README.md and our About page.  
 
 Please follow the next chapters for more detailed instructions. 


### PR DESCRIPTION
I updated steps "4", "5", "6", and "7" to include corresponding links to the more in-depth descriptions of each step, for the reader's convenience. This may be especially useful for returning contributors if they want to skip directly to desired instructions.